### PR TITLE
remove connection ID and stateless reset token from frame

### DIFF
--- a/draft-munizaga-quic-new-preferred-address.md
+++ b/draft-munizaga-quic-new-preferred-address.md
@@ -125,9 +125,6 @@ NEW_PREFERRED_ADDRESS Frame {
   IPv4 Port (16),
   IPv6 Address (128),
   IPv6 Port (16),
-  Connection ID Length (8),
-  Connection ID (..),
-  Stateless Reset Token (128),
 }
 ~~~
 


### PR DESCRIPTION
The Preferred Address transport parameter has a CID field because NCID frames can't be sent during the handshake, and we wanted to allow the client to immediately initiate migration when completing the handshake, without having to wait for the NCID frame.

Importantly, the CID sent in the TP is not treated differently from CIDs obtained in NCID frames. For example, if a client doesn't honor the migration request, this CID can be used on the original path. Furthermore, the client is free to use a CID from a NCID frame to migrate to the preferred address.

After handshake completion (which is when this frame can be sent, PR making this explicit incoming) we can rely on the NCID mechanism.