### PR TITLE
specify frame properties

### DIFF
--- a/draft-munizaga-quic-new-preferred-address.md
+++ b/draft-munizaga-quic-new-preferred-address.md
@@ -131,6 +131,8 @@ NEW_PREFERRED_ADDRESS Frame {
 }
 ~~~
 
+NEW_PREFERRED_ADDRESS frames are ack-eliciting, and MUST only be sent in the
+application data packet number space.
 
 # Security Considerations
 


### PR DESCRIPTION
Nothing interesting here, but we need to specify this. The frame is ack-eliciting and can only be sent in the application-data packet number space.