### PR TITLE
specify 0-RTT properties

### DIFF
--- a/draft-munizaga-quic-new-preferred-address.md
+++ b/draft-munizaga-quic-new-preferred-address.md
@@ -108,8 +108,7 @@ Servers do not need to send this transport parameter. Receiving this transport
 parameter signals to the server that the client understands the New Preferred
 Address frame.
 
-Endpoints MUST NOT remember the value of this extension for 0-RTT. This means
-that the NEW_PREFERRED_ADDRESS frame cannot be used in 0-RTT packets.
+Endpoints MUST NOT remember the value of this extension for 0-RTT.
 
 # New Preferred Address Frame
 


### PR DESCRIPTION
Again, nothing interesting here, but RFC 9000 requires us to define the 0-RTT properties of any extension.

Since clients can't send the NEW_PREFERRED_ADDRESS frame, it's not possible to send them in 0-RTT in the first place. It would therefore make no difference whatsoever if endpoints remembered the value of the TP.