### PR TITLE
fix document metadata

### DIFF
--- a/draft-munizaga-quic-new-preferred-address.md
+++ b/draft-munizaga-quic-new-preferred-address.md
@@ -1,18 +1,23 @@
 ---
 title: "QUIC New Server Preferred Address"
 category: std
-
 docname: draft-munizaga-quic-new-preferred-address-latest
-submissiontype: IETF
-number:
-date:
-consensus: true
-v: 3
-area: Transport
-workgroup: QUIC
-keyword:
- - Connection Migration
- - Server's Preferred Address
+
+ipr: trust200902
+area: "Transport"
+workgroup: "QUIC"
+keyword: Internet-Draft
+venue:
+  group: "QUIC"
+  type: "Working Group"
+  mail: "quic@ietf.org"
+  arch: "https://mailarchive.ietf.org/arch/browse/quic/"
+  github: "MarcoPolo/new-preferred-address"
+  latest: "https://marcopolo.github.io/new-preferred-address/draft-munizaga-quic-new-preferred-address.html"
+
+stand_alone: yes
+smart_quotes: no
+pi: [toc, sortrefs, symrefs]
 
 author:
  -


### PR DESCRIPTION
I believe this should have been set the first time the GitHub Actions workflow was run, but I suspect there was some kind of permission issue.

With this metadata, the draft now correctly links back to this GitHub repo, making it easier for people to open issues and PRs.