### PR TITLE
remove suggestion that the server probes the path first

### DIFF
--- a/draft-munizaga-quic-new-preferred-address.md
+++ b/draft-munizaga-quic-new-preferred-address.md
@@ -109,7 +109,7 @@ A server can use an NEW_PREFERRED_ADDRESS frame to request the client to
 migrate the connection to the provided server address. Upon receiving an
 NEW_PREFERRED_ADDRESS, the client MAY initiate migration. If the
 client does migrate it MUST adhere to the client behavior defined in {{Section
-9.6 of QUIC-TRANSPORT}}, with exceptions specified in {{changes}}.
+9.6 of QUIC-TRANSPORT}}.
 
 The NEW_PREFERRED_ADDRESS is defined as follows:
 
@@ -152,16 +152,6 @@ connection ID. The server MAY bundle a NEW_CONNECTION_ID frame with the
 NEW_PREFERRED_ADDRESS. Likewise, the client should ensure the same to allow the
 server to probe new paths.
 
-# Changes to Server's Preferred Address from RFC 9000 {#changes}
-
-If a client advertises support for this extension it should modify its
-migration behavior to a server's preferred address as follows.
-
-Clients MUST support migrating to a new server address mid connection.
-
-Clients SHOULD respond to PATH_CHALLENGE frames from the server from new paths,
-even if the client has not initiated a migration. This allows the server to
-probe viable paths before sending an NEW_PREFERRED_ADDRESS frame.
 
 # Security Considerations
 
@@ -177,9 +167,7 @@ and request a migration from all of them at the same time to a victim endpoint.
 If the clients all migrate at the same time, they may overload or otherwise
 negatively impact the victim endpoint.
 
-Clients MAY defer migration until after a PATH_CHALLENGE frame is received from
-the server's new preferred address. Clients may also mitigate this by randomly
-delaying the migration.
+Clients may mitigate this by randomly delaying the migration.
 
 # IANA Considerations
 
@@ -243,9 +231,6 @@ TODO acknowledge.
 
 # Questions
 {:numbered="false"}
-
-- Any new security considerations from allowing a server to send path challenge
-  frames?
 
 - Any new security conserations from allowing a dynamically chosen preferred
   address?


### PR DESCRIPTION
Server-initiated probes would be dropped by a NAT, so the only thing a server can possibly learn from initiating path probing is "path works" or "path might work", but never "path doesn't work".